### PR TITLE
Fix nil pointer dereference error in device manager.

### DIFF
--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -108,10 +108,13 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		nodeConfig:        nodeConfig,
 		cadvisorInterface: cadvisorInterface,
 	}
-
+	
+	cm.topologyManager = topologymanager.NewFakeManager()
+	
 	klog.Infof("Creating device plugin manager: %t", devicePluginEnabled)
 	if devicePluginEnabled {
 		cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager)
+         	cm.topologyManager.AddHintProvider(cm.deviceManager)
 	} else {
 		cm.deviceManager, err = devicemanager.NewManagerStub()
 	}


### PR DESCRIPTION
Initializing cm.topologyManager prevents the devicemanager/manager.go file from running into a "invalid memory address or nil pointer dereference" runtime error.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This PR copies text from the linux container manager to the windows container manager. 
It initializes cm.topologyManager  and prevents a nil pointer dereference.

**Which issue(s) this PR fixes**:

Not a known issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
